### PR TITLE
Fix sticky input and task list scroll

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,6 +104,25 @@ class TodayTodo {
     setupEventListeners() {
         // Task input
         const taskInput = document.getElementById('taskInput');
+        
+        // Prevent soft keyboard from appearing on focus until user starts typing
+        let hasUserInteracted = false;
+        
+        taskInput.addEventListener('focus', (e) => {
+            // Only show keyboard if user has already interacted
+            if ('ontouchstart' in window && !hasUserInteracted) {
+                e.target.blur();
+            }
+        });
+        
+        taskInput.addEventListener('touchstart', () => {
+            hasUserInteracted = true;
+        });
+        
+        taskInput.addEventListener('input', () => {
+            hasUserInteracted = true;
+        });
+        
         taskInput.addEventListener('keypress', (e) => {
             if (e.key === 'Enter' && taskInput.value.trim()) {
                 this.addTask(taskInput.value.trim());

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,7 @@ body {
     display: flex;
     flex-direction: column;
     padding-bottom: 100px; /* Space for fixed input container */
+    min-height: 0; /* Allow flex item to shrink */
 }
 
 .input-container {
@@ -107,6 +108,11 @@ body {
     color: #ffffff;
     outline: none;
     transition: border-color 0.2s ease;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    /* Prevent zoom on iOS */
+    font-size: 16px;
 }
 
 #taskInput:focus {
@@ -120,6 +126,11 @@ body {
 .task-list {
     list-style: none;
     flex: 1;
+    overflow-y: auto; /* Only scroll when content overflows */
+    min-height: 0; /* Allow flex item to shrink */
+    /* Ensure the list doesn't take up unnecessary space when empty */
+    display: flex;
+    flex-direction: column;
 }
 
 .task-item {
@@ -128,6 +139,7 @@ body {
     padding: 16px 0;
     border-bottom: 1px solid #222;
     animation: slideIn 0.3s ease;
+    flex-shrink: 0; /* Prevent items from shrinking */
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
Improve task input field soft keyboard behavior on mobile and ensure the task list only scrolls when its content overflows.

---
<a href="https://cursor.com/background-agent?bcId=bc-a108076e-de7f-46e2-bb46-7e9afdf55530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a108076e-de7f-46e2-bb46-7e9afdf55530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

