### PR TITLE
Timer auto-starts on open

### DIFF
--- a/app.js
+++ b/app.js
@@ -1672,6 +1672,7 @@ class TodayTodo {
         document.getElementById('timerTaskName').textContent = task.text || '';
 
         document.getElementById('timerOverlay').classList.add('show');
+        this.playTimer();
     }
 
     closeTimer() {
@@ -1807,12 +1808,13 @@ class TodayTodo {
             return;
         }
 
-        // Show overlay paused at the correct remaining time
+        // Show overlay and resume counting
         this.drawTimerTicks();
         this.updateTimerDisplay();
         this.updateTimerPlayBtn();
         document.getElementById('timerTaskName').textContent = task.text || '';
         document.getElementById('timerOverlay').classList.add('show');
+        this.playTimer();
     }
 
     drawTimerTicks() {


### PR DESCRIPTION
## Summary

- Timer countdown starts automatically as soon as the overlay opens — no need to tap the play button
- Applies both when opening a timer from the task list and when restoring a running timer after the app is reopened

## Test plan

- [ ] Tap a task's duration badge → timer overlay opens and is already counting down
- [ ] Close the app while a timer is running, reopen → timer resumes automatically
- [ ] Pause button still works to stop the countdown
- [ ] Play button still works to resume after pausing

https://claude.ai/code/session_01Xe425n5YR4G9oTXfbRuMHC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe425n5YR4G9oTXfbRuMHC)_