### PR TITLE
Settings: reset countdown as subtitle of "Day resets at"

### DIFF
--- a/app.js
+++ b/app.js
@@ -420,7 +420,7 @@ class TodayTodo {
         
         // Email Feedback link in settings
         document.getElementById('emailFeedbackLink').addEventListener('click', () => {
-            const version = '1.2.7';
+            const version = '1.3.1';
             const subject = `Feedback for Today v${version}`;
             const mailtoLink = `mailto:today@annafilou.com?subject=${encodeURIComponent(subject)}`;
             window.location.href = mailtoLink;

--- a/index.html
+++ b/index.html
@@ -108,7 +108,10 @@
             </div>
             <div class="modal-body">
                 <div class="setting-item">
-                <span class="setting-label">Day resets at</span>
+                <div class="setting-info">
+                    <span class="setting-label">Day resets at</span>
+                    <span class="setting-subtitle">Next reset in <span id="resetCountdown">--:--</span></span>
+                </div>
                 <button class="time-display" id="resetTimeDisplay">4:00</button>
                 <input type="time" id="resetTime" value="04:00" style="display: none;">
             </div>
@@ -147,10 +150,6 @@
                 <button class="toggle-btn" id="autoAddEmojisToggle">
                     <span class="toggle-value">Yes</span>
                 </button>
-            </div>
-            <div class="setting-item">
-                <span class="setting-label">Time until next reset</span>
-                <span class="setting-value" id="resetCountdown">--:--</span>
             </div>
             <div class="setting-item setting-link" id="aboutBtn">
                 <span class="setting-label">How to use</span>

--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=1.2.7">
+    <link rel="stylesheet" href="styles.css?v=1.3.1">
     <script src="https://unpkg.com/suncalc@1.9.0/suncalc.js"></script>
     <script src="emoji-autotag.js"></script>
-    <script src="app.js?v=1.2.7" defer></script>
+    <script src="app.js?v=1.3.1" defer></script>
 </head>
 <body>
     <noscript>
@@ -166,7 +166,7 @@
                     <button class="clear-all-btn" id="clearAllTasks">Clear All Tasks</button>
                 </div>
                 <div class="setting-item version-item">
-                    <span class="version-label">Version 1.2.7</span>
+                    <span class="version-label">Version 1.3.1</span>
                 </div>
             </div>
         </div>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Today Todo",
     "short_name": "Today Todo",
     "description": "A minimal, phone-optimized todo app that enforces daily focus",
-    "version": "1.2.7",
+    "version": "1.3.1",
     "start_url": "/today/",
     "display": "standalone",
     "background_color": "#000000",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const VERSION = '1.2.7';
+const VERSION = '1.3.1';
 const CACHE_NAME = `today-todo-v${VERSION}`;
 const urlsToCache = [
     '/today/',


### PR DESCRIPTION
## Summary

- Removes the standalone "Time until next reset" setting row
- Adds "Next reset in HH:MM" as a subtitle under "Day resets at", matching the style of Location Access and Only show awake time

https://claude.ai/code/session_01Xe425n5YR4G9oTXfbRuMHC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe425n5YR4G9oTXfbRuMHC)_