### PR TITLE
Bump version to 1.3.2 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,37 +10,53 @@ A minimal, phone-optimized todo app that enforces daily focus by resetting each 
 **📝 Task Management:**
 - Add tasks using the prominent + button (opens modal dialog)
 - Check off completed tasks
-- Edit tasks by clicking on them
-- Delete tasks by swiping left or right (native app-like gesture)
-- Sort tasks: toggle between creation order (default) and duration order (longest first, no duration at bottom)
+- Edit tasks by tapping on them
+- Delete tasks by swiping left (native app-like gesture, 50% threshold)
+- Undo accidental deletes with a 5-second toast notification
 - Clear all tasks via Settings (with confirmation)
 
 **⏰ Duration Tracking:**
 - Automatically detects time estimates in task names (1h, 30min, 2h30m, etc.)
 - Shows total remaining time for unfinished tasks in the header
-- Duration text appears in darker color within task names
-- **Duration Pills**: Quick-select buttons (5m, 15m, 30m, 1h, 2h, 3h, 0) for fast task creation
+- **Duration Pills**: Quick-select buttons (0, 5m, 15m, 30m, 1h, 2h, 3h) for fast task creation
 - **Auto-submit**: Selecting a duration pill with existing text immediately creates the task
-- **Round Duration**: Optional feature to round total time up to nearest 30-minute increment
+- **Round Duration**: Optional setting to round total time up to the nearest 30-minute increment
+
+**⏱️ Countdown Timer:**
+- Tap the duration badge on any task to open a full-screen countdown timer
+- Auto-starts immediately when opened
+- Visual clock face (SVG pie sector) that drains clockwise as time elapses
+- Multi-clock layout for tasks longer than 1 hour: big clock = current draining hour, small clocks = future hours still waiting
+- For tasks > 4 hours: shows 2 small clocks + a red-bordered "+n" overflow label
+- Shows task name above the clock (3-line clamp with ellipsis)
+- Displays projected finish time (e.g. "→ 14:30")
+- On close, automatically subtracts elapsed time from the task duration (rounded down to nearest 5 minutes)
+- Timer state is persisted to localStorage — survives app restarts and background/foreground cycles
+
+**🔢 Sort Modes:**
+- Cycle through three modes using the sort button (bottom-left) or the Sort by setting:
+  - **Creation** (default): tasks in the order they were added, stable across reorders
+  - **Duration**: longest-first, no-duration and completed tasks at the bottom
+  - **Manual**: drag-and-drop reordering with a grip handle on each task; order is persisted and survives switching to other sort modes and back
 
 **🔄 Daily Reset Philosophy:**
-- Automatic reset at customizable time (default 4 AM, configurable in settings)
-- Modal automatically appears when reset time is reached (checks every minute)
+- Automatic reset at a customizable time (default 4 AM, configurable in settings)
+- Modal automatically appears when reset time is reached (checks every minute, and on app foreground)
 - Shows yesterday's unfinished tasks in a non-dismissible modal
-- Only option is "Clear & start today" - modal cannot be dismissed by clicking outside
-- No carrying over old tasks - forces you to consciously re-add what's truly important
+- Only option is "Clear & start today" — modal cannot be dismissed by tapping outside
+- No carrying over old tasks — forces you to consciously re-add what's truly important
 - Custom 24-hour time picker works across all devices and platforms
-- Perfect for night owls who want their "new day" to start at a different time
+- Reset countdown shown as a subtitle under the "Day resets at" setting
 
 **📱 Design:**
 - Clean black interface optimized for phones
 - Fixed header showing day, date, and remaining time
-- **Day Progress Bar**: Visual indicator showing percentage of day elapsed
-- **Sunrise/Sunset Indicators**: Shows actual sunrise/sunset times using [SunCalc](https://github.com/mourner/suncalc) library (requires location permission)
-- Prominent empty state with philosophical messaging
-- Bottom navigation with pill-shaped buttons
+- **Day Progress Bar**: Thin bar below the header showing how much of the day has elapsed
+- **Sunrise/Sunset Indicators**: Shows actual sunrise/sunset times using [SunCalc](https://github.com/mourner/suncalc) (requires location permission); hidden when outside the current awake window
+- **Only Show Awake Time**: Optional setting that makes the progress bar represent your 16-hour awake window (wake time = reset time + 8h) instead of the full 24-hour day
+- Bottom navigation: sort button (left), add button (center), settings button (right)
 - OLED-friendly dark theme
-- App-like interface with proper mobile navigation
+- Prominent empty state with philosophical messaging
 
 **🔄 PWA Updates:**
 - Automatic update detection when new versions are available
@@ -54,42 +70,47 @@ If something was truly important, you'll remember to add it again today. This pr
 
 ## Tech stack
 
-Only HTML, CSS and JS. PWA. Saves tasks in local storage.
+Only HTML, CSS and JS. PWA. Saves tasks in localStorage. No build step, no dependencies beyond SunCalc (CDN) and Inter (Google Fonts).
 
 ## Deployment & Updates
 
 ### Version Update Process
-When you make changes to the code, you **must** update the version number in 3 places:
+When you make changes to the code, you **must** update the version number in 4 places:
 
-1. **Update `sw.js`**: Change the `VERSION` constant (e.g., `'1.0.13'` → `'1.0.13'`)
-2. **Update `manifest.json`**: Change the `version` field to match
-3. **Update `index.html`**: Change version in `?v=` query parameters on CSS and JS file links
-4. **Commit and Push**: Deploy to your hosting
+1. **`sw.js`**: Change the `VERSION` constant — creates a new cache name and triggers the update flow
+2. **`manifest.json`**: Change the `version` field to match
+3. **`index.html`**: Change the `?v=` query parameters on the CSS and JS `<link>`/`<script>` tags
+4. **`app.js`**: Change the version string in the `emailFeedbackLink` click handler (subject line)
+
+Then commit and push.
 
 ### Why Version Updates Matter
-- **Service Worker Detection**: Changing the `VERSION` in `sw.js` creates a new cache name
-- **Forces Refresh**: Service worker detects the change and installs new version
+- **Service Worker Detection**: Changing `VERSION` in `sw.js` creates a new cache name
+- **Forces Refresh**: Service worker detects the change and installs the new version
 - **Cache Busting**: Old caches are automatically cleaned up
-- **User Updates**: Users get notified of the new version
+- **User Updates**: Users see a banner and can refresh with one tap
 
 ### How Updates Work
-1. **Detection**: Service worker detects new `sw.js` file with different version
-2. **Notification**: Users see update banner when new version is available
+1. **Detection**: Service worker detects a new `sw.js` file with a different version
+2. **Notification**: Users see an update banner when the new version is ready
 3. **Installation**: One-click update process
-4. **Activation**: Page automatically refreshes with new version
+4. **Activation**: Page automatically refreshes with the new version
 5. **Cache Cleanup**: Old caches are deleted, new version is cached
 
 ## Development Notes
 
 ### Testing/Debugging Features
-- **Simulate Next Day**: Long press the Settings button (gear icon) for 1 second to trigger the daily reset modal. Normal tap opens Settings, long press triggers the reset simulation
+- **Simulate Next Day**: Long press the Settings button (gear icon) for 1 second to trigger the daily reset modal. Normal tap opens Settings, long press triggers the reset simulation.
 
-### Settings & Time Picker
-- **Custom Time Picker**: 24-hour grid interface for setting daily reset time, works across all devices
-- **Round Duration Toggle**: Optional feature to round total time up to nearest 30-minute increment
-- **Location Access**: Enables sunrise/sunset indicators in progress bar (uses [SunCalc](https://github.com/mourner/suncalc) library)
-- **Reset Countdown**: Shows time until next daily reset for debugging purposes
-- **Settings UI**: Toggle buttons show checkmarks when enabled (✓Yes vs No)
+### Settings Reference
+| Setting | Default | Description |
+|---|---|---|
+| Day resets at | 04:00 | Custom 24-hour time picker. Subtitle shows countdown to next reset. |
+| Sort by | Creation | Cycles: Creation → Duration → Manual |
+| Round total duration up | No | Rounds header total to nearest 30 min |
+| Location Access | No | Enables sunrise/sunset indicators (SunCalc) |
+| Only show awake time | No | Progress bar = awake window (reset+8h → reset); hides out-of-window sun indicators |
+| Auto-add emojis | Yes | Prepends a relevant emoji to task names on creation |
 
 ### Development Best Practices
 
@@ -125,18 +146,19 @@ element.addEventListener('touchend', (e) => {
 
 ### Custom CSS Implementations
 - **Dashed Borders**: Uses `repeating-linear-gradient` backgrounds for precise control over dash/gap spacing (2px dash + 5px gap)
-- **Dynamic Viewport Height**: Uses `100dvh` instead of `100vh` for proper mobile browser support
-  - **Why**: Chrome's URL bar causes `100vh` to include hidden space, creating unnecessary scrolling
-  - **Solution**: `100dvh` dynamically adjusts based on URL bar visibility
-  - **Result**: Task list only scrolls when content truly overflows, not because of viewport miscalculation
-- **Swipe-to-Delete**: Custom implementation with two-stage visual feedback (gray "Delete" background, red when threshold reached)
-  - **Gesture Detection**: 10-pixel threshold to differentiate taps from swipes
-  - **Direction Restriction**: Only left swipes trigger delete (right swipes ignored)
-  - **Visual Feedback**: Background color changes and extends full width as task slides away
+- **Dynamic Viewport Height**: Uses `100svh` (small viewport height) for proper mobile PWA support — avoids URL bar causing unnecessary scrollbars
+- **Swipe-to-Delete**: Custom touch implementation with two-stage feedback (gray "Delete" label → red background when 50vw threshold is crossed). Left swipe only; right swipe and vertical scroll are ignored.
+- **Drag-to-Reorder**: HTML5 Drag API (desktop) + `elementFromPoint` touch tracking (mobile). Position determined by cursor/touch top/bottom half of target. Sticky edges: dragging past the first or last item snaps the indicator to first/before or last/after.
+
+### Timer Architecture
+- `timerOriginalSeconds` + `timerRemainingSeconds` → `getTimerBuckets()` computes which hour bucket is currently draining and which are still waiting
+- Big clock = current draining bucket, small clocks = future buckets (static until their turn)
+- `timerPlayStartAt` + `timerRemainingAtPlayStart` store the wall-clock anchor so elapsed time is always computed from real time, not tick accumulation — survives tab switching and backgrounding
+- On close: `elapsedSeconds` → rounded down to 5-min increments → subtracted from `task.duration`
 
 ### Toast Notifications
 - **User Feedback**: Small notifications appear above bottom navigation for task actions and sort mode changes
-- **Undo Functionality**: Swipe-to-delete includes 5-second undo option with "Undo" link
+- **Undo Functionality**: Swipe-to-delete includes a 5-second undo toast with an "Undo" link
 
 ### Task Animations
 - **Check Animation**: When marking tasks complete, checkbox bounces and fades from white to gray
@@ -150,28 +172,22 @@ element.addEventListener('touchend', (e) => {
 #### Chrome Android - Keyboard Issues
 - **Software Keyboard Covers Input**: ~~On Chrome Android, when the add/edit task overlay appears, the software keyboard covers the input field instead of positioning above it.~~
   - **Status**: ✅ **Resolved** using Visual Viewport API (input now stays visible)
-  - **Solution**: 
+  - **Solution**:
     - Uses `window.visualViewport` to detect keyboard height changes
     - Delays focus by 2 animation frames to avoid race condition with keyboard transition
     - Listens to viewport `resize`/`scroll` events to keep input centered when keyboard opens
     - Calls `focus({ preventScroll: true })` then manually scrolls input into view
   - **Why it works**: Chrome's keyboard opening is async; waiting for transition frames prevents focusing with stale geometry. Visual Viewport API provides real-time keyboard height, allowing proper repositioning.
-  - **Impact**: Input stays visible, but see note below about overlay behavior
 
 - **Overlay Scrolls Page Content (Chrome Android)**: When the keyboard appears, Chrome Android pushes the page content upwards instead of treating the overlay as a true fixed overlay. Works correctly in Kiwi Browser (content stays in place behind overlay).
   - **Status**: Open for investigation
   - **Current Behavior**: Visual Viewport API ensures input stays visible, but page content beneath the overlay shifts when keyboard opens
   - **Ideal Behavior**: Overlay should remain truly fixed with page content stationary behind it
-  - **Impact**: Non-breaking - input is functional, but visual behavior differs from other browsers
+  - **Impact**: Non-breaking — input is functional, but visual behavior differs from other browsers
 
 - **Keyboard Autocomplete Bar**: Chrome Android shows a QuickType/autofill bar above the keyboard with irrelevant suggestions (passwords, addresses, credit cards) even though the input is `type="text"` for task names.
-  - **Status**: ✅ **User-Resolvable** - Can be resolved by changing autofill provider
-  - **Developer Fixes Attempted** (all ineffective):
-    - `autocomplete="off"` - ignored
-    - `aria-autocomplete="none"` - ignored
-    - `inputmode="text"` - ignored
-    - `autocapitalize="sentences"` - ignored
-    - `name="taskNameField"` (generic, non-PII) - ignored
-  - **Chrome Behavior**: Completely disregards developer preferences and HTML standards; uses its own "smart" heuristics to force autofill suggestions regardless of explicit opt-out attributes
-  - **User Solution**: Change autofill provider from Chrome to a password manager (e.g., Bitwarden, 1Password) which provides better control over autofill behavior
-  - **Impact**: Minor UX issue - can be resolved by using a different autofill provider
+  - **Status**: ✅ **User-Resolvable** — can be resolved by changing autofill provider
+  - **Developer Fixes Attempted** (all ineffective): `autocomplete="off"`, `aria-autocomplete="none"`, `inputmode="text"`, `autocapitalize="sentences"`, `name="taskNameField"`
+  - **Chrome Behavior**: Completely disregards developer preferences; uses its own heuristics to force autofill regardless of explicit opt-out attributes
+  - **User Solution**: Change autofill provider from Chrome to a password manager (e.g., Bitwarden, 1Password)
+  - **Impact**: Minor UX issue

--- a/app.js
+++ b/app.js
@@ -421,7 +421,7 @@ class TodayTodo {
         
         // Email Feedback link in settings
         document.getElementById('emailFeedbackLink').addEventListener('click', () => {
-            const version = '1.3.1';
+            const version = '1.3.2';
             const subject = `Feedback for Today v${version}`;
             const mailtoLink = `mailto:today@annafilou.com?subject=${encodeURIComponent(subject)}`;
             window.location.href = mailtoLink;

--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=1.3.1">
+    <link rel="stylesheet" href="styles.css?v=1.3.2">
     <script src="https://unpkg.com/suncalc@1.9.0/suncalc.js"></script>
     <script src="emoji-autotag.js"></script>
-    <script src="app.js?v=1.3.1" defer></script>
+    <script src="app.js?v=1.3.2" defer></script>
 </head>
 <body>
     <noscript>
@@ -166,7 +166,7 @@
                     <button class="clear-all-btn" id="clearAllTasks">Clear All Tasks</button>
                 </div>
                 <div class="setting-item version-item">
-                    <span class="version-label">Version 1.3.1</span>
+                    <span class="version-label">Version 1.3.2</span>
                 </div>
             </div>
         </div>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Today Todo",
     "short_name": "Today Todo",
     "description": "A minimal, phone-optimized todo app that enforces daily focus",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "start_url": "/today/",
     "display": "standalone",
     "background_color": "#000000",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const VERSION = '1.3.1';
+const VERSION = '1.3.2';
 const CACHE_NAME = `today-todo-v${VERSION}`;
 const urlsToCache = [
     '/today/',


### PR DESCRIPTION
## Summary

- Bumps version from 1.3.1 → 1.3.2 in all four places (`sw.js`, `manifest.json`, `index.html`, `app.js`)
- Rewrites README to accurately reflect the current feature set

### What changed in the README

**Added (missing features):**
- Countdown timer — multi-clock layout, auto-start, persistence, duration subtraction on close, timer architecture notes
- Manual sort mode — drag-and-drop, grip handle, persistence across mode cycles
- "Only show awake time" setting and how the awake window is calculated
- Reset countdown subtitle under "Day resets at"
- Settings reference table

**Corrected:**
- Swipe-to-delete is left-only (not "left or right")
- Sort mode now cycles through three options, not two
- Version update process now lists all four files (previously listed 3, missed `app.js`)

**Improved:**
- Drag-and-drop implementation details (sticky edges, HTML5 + touch)
- Cleaned up stale/vague wording throughout

https://claude.ai/code/session_01Xe425n5YR4G9oTXfbRuMHC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe425n5YR4G9oTXfbRuMHC)_